### PR TITLE
Use more structural URL handling.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -16,7 +16,7 @@ type LoginResponse struct {
 }
 
 func (me *MatrixClient) PasswordLogin(user string, pass string) error {
-	uri := me.server + "/_matrix/client/r0/login"
+	uri := me.endpoints.login
 	req := LoginRequest{
 		Password: pass,
 		Medium:   "email",
@@ -25,7 +25,7 @@ func (me *MatrixClient) PasswordLogin(user string, pass string) error {
 	}
 
 	var resp LoginResponse
-	err := me.makeMatrixRequest("POST", uri, req, &resp)
+	err := me.makeMatrixRequest("POST", uri.String(), req, &resp)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"path"
 )
 
 type MatrixClient struct {
-	server        string
+	server        url.URL
+	endpoints     endpoints
 	accessToken   string
 	refreshToken  string
 	transactionID int
@@ -17,19 +20,35 @@ type MatrixClient struct {
 	nextBatch     string
 }
 
+type endpoints struct {
+	login     url.URL
+	room      url.URL
+	sync      url.URL
+	sendEvent url.URL
+}
+
 type ErrorResponse struct {
 	ErrorCode    string `json:"errcode"`
 	ErrorMessage string `json:"error"`
 }
 
-func NewClient(server string) MatrixClient {
+func NewClient(server string) (*MatrixClient, error) {
 	client := http.Client{}
-	return MatrixClient{
-		server:        server,
+	u, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+	return &MatrixClient{
+		server: *u,
+		endpoints: endpoints{
+			login: url.URL{Scheme: u.Scheme, Host: u.Host, Path: "/_matrix/client/r0/login"},
+			room:  url.URL{Scheme: u.Scheme, Host: u.Host, Path: "/_matrix/client/r0/rooms/"},
+			sync:  url.URL{Scheme: u.Scheme, Host: u.Host, Path: "/_matrix/client/r0/sync"},
+		},
 		transactionID: 0,
 		client:        client,
 		nextBatch:     "",
-	}
+	}, nil
 }
 
 func (me *MatrixClient) makeMatrixRequest(method string, uri string, reqIf interface{}, respIf interface{}) error {
@@ -72,8 +91,13 @@ func (me *MatrixClient) makeMatrixRequest(method string, uri string, reqIf inter
 }
 
 func (me *MatrixClient) JoinRoom(roomID string) error {
-	uri := me.server + "/_matrix/client/r0/rooms/" + roomID + "/join?access_token=" + me.accessToken
-	err := me.makeMatrixRequest("POST", uri, nil, nil)
+	uri := me.endpoints.room
+	uri.Path += path.Join(roomID, "join")
+	params := url.Values{}
+	params.Add("access_token", me.accessToken)
+	uri.RawQuery = params.Encode()
+
+	err := me.makeMatrixRequest("POST", uri.String(), nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Like it says on the tin.  Should be functionally unchanged, while now using `net/url` for manipulating the rest endpoints and parameters.

If the `server` argument to `NewClient` isn't parsable as a url, it will now return an error.
